### PR TITLE
Fix incorrect translation on keywords.js

### DIFF
--- a/overpy/doc/keywords.js
+++ b/overpy/doc/keywords.js
@@ -96,7 +96,7 @@ const customGameSettingsKw =
         "pt-BR": "Sim",
         "ru-RU": "Да",
         "zh-CN": "是",
-        "zh-TW": "啟用"
+        "zh-TW": "是"
     },
     "_no": {
         "guid": "0000000058F4",
@@ -110,7 +110,7 @@ const customGameSettingsKw =
         "pt-BR": "Não",
         "ru-RU": "Нет",
         "zh-CN": "否",
-        "zh-TW": "停用"
+        "zh-TW": "否"
     }
 }
 //end-json


### PR DESCRIPTION
fix incorrect translation on keywords.js
(zh-TW)
![Error](https://user-images.githubusercontent.com/42492294/76955619-797f3700-694d-11ea-9ef5-4627ff978beb.jpg)
